### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ It's because you should check object itself, not its class, to match with
 ['test', 'me'].select(&fltr(itself: String)) # => ['test', 'me']
 ```
 
-`#itself` method is available in Ruby >= 2.0, and easily backported to
+`#itself` method is available in Ruby >= 2.2, and easily backported to
 earlier versions.
 
 ## License


### PR DESCRIPTION
Object#itself is available since ruby 2.2, not 2.0

```
2.1.5 :001 > itself
NameError: undefined local variable or method `itself' for main:Object
    from (irb):1
    from /Users/gordon/.rvm/rubies/ruby-2.1.5/bin/irb:11:in `<main>'
2.1.5 :002 >
```
